### PR TITLE
fix: fix error when trying to rotate with snapping turned on

### DIFF
--- a/addons/gd-blender-3d-shortcuts/plugin.gd
+++ b/addons/gd-blender-3d-shortcuts/plugin.gd
@@ -393,7 +393,7 @@ func mouse_transform(event):
 					var quat = _editing_transform.basis.get_rotation_quaternion()
 					if is_snapping:
 						var snap = Vector3.ONE * (rotate_snap if not precision_mode else rotate_snap * precision_factor)
-						quat.set_euler(quat.get_euler().snapped(snap))
+						quat.from_euler(quat.get_euler().snapped(snap))
 					_applying_transform.basis = Basis(quat)
 			SESSION.SCALE:
 				if constraint_axis.x:


### PR DESCRIPTION
The function Quaternion.set_euler() was renamed to from_euler(), so trying to rotate with snapping on fires errors currently.

Thanks much for this add-on, it's a godsend!