### PR TITLE
Make the dashed line invisible during translation / grab

### DIFF
--- a/addons/gd-blender-3d-shortcuts/plugin.gd
+++ b/addons/gd-blender-3d-shortcuts/plugin.gd
@@ -375,6 +375,7 @@ func _forward_3d_draw_over_viewport(overlay):
 		SESSION.TRANSLATE:
 			var translation = _applying_transform.origin
 			overlay_label.text = ("Translate (%.3f, %.3f, %.3f) %s %s %s" % [translation.x, translation.y, translation.z, global_or_local, along_axis, snapped])
+			line_color = Color.TRANSPARENT
 		SESSION.ROTATE:
 			var rotation = _applying_transform.basis.get_euler()
 			overlay_label.text = ("Rotate (%.3f, %.3f, %.3f) %s %s %s" % [rad_to_deg(rotation.x), rad_to_deg(rotation.y), rad_to_deg(rotation.z), global_or_local, along_axis, snapped])


### PR DESCRIPTION
In Blender, when 3D objects are translated, the dashed line from the transform origin to the mouse cursor is not visible. You can only see the line during rotation and scale.