### PR TITLE
Fix unable to expand nested resource editor in inspector

### DIFF
--- a/addons/gd-blender-3d-shortcuts/plugin.gd
+++ b/addons/gd-blender-3d-shortcuts/plugin.gd
@@ -221,7 +221,7 @@ func _handles(object):
 	if object is Node3D:
 		_is_editing = get_editor_interface().get_selection().get_selected_nodes().size()
 		return _is_editing
-	else:
+	elif object.get_class() == "MultiNodeEdit": # Explicitly handle MultiNodeEdit, otherwise, it will active when selected Resource
 		_is_editing = get_editor_interface().get_selection().get_transformable_selected_nodes().size() > 0
 		return _is_editing
 	return false


### PR DESCRIPTION
Fix unable to expand nested resource editor in inspector (#21)

But the console still printing error `editor/editor_node.cpp:8240 - Condition "plugins_list.has(p_plugin)" is true.`