### PR TITLE
Add a check for meta_pressed key event #31

### DIFF
--- a/addons/gd-blender-3d-shortcuts/plugin.gd
+++ b/addons/gd-blender-3d-shortcuts/plugin.gd
@@ -150,7 +150,7 @@ func _input(event):
 									debug_draw_pie_menu.hide()
 									get_viewport().set_input_as_handled()
 								else:
-									if not (event.ctrl_pressed or event.alt_pressed or event.shift_pressed) and current_session == SESSION.NONE:
+									if not (event.ctrl_pressed or event.alt_pressed or event.shift_pressed or event.meta_pressed) and current_session == SESSION.NONE:
 										show_debug_draw_pie_menu()
 										get_viewport().set_input_as_handled()
 
@@ -558,6 +558,10 @@ func update_pivot_point():
 func start_session(session, camera, event):
 	if get_editor_interface().get_selection().get_transformable_selected_nodes().size() == 0:
 		return
+
+	if event.meta_pressed
+		return
+
 	current_session = session
 	_camera = camera
 	_is_global_on_session = is_global


### PR DESCRIPTION
Since Mac's have a command key which is used as a key modifier for things like saving, undoing, it seems like for any of the blender shortcuts that overlap with godot's bindings share a similar issue.

For example:

* Cmd + Z doesn't undo and just opens the pi menu.
* Cmd + S saves but also enters into scale mode at the same time
*Cmd + R builds and runs the current scene but also enters into rotate mode.

Did a little digging and found the key event for `meta_pressed` should be added to resolve this. Godot doc reference for this key event. 

https://docs.godotengine.org/en/stable/classes/class_inputeventwithmodifiers.html#class-inputeventwithmodifiers-property-meta-pressed

I added a check to the pie menu display code path, so if the `event.meta_pressed` is active, it won't show the pie menu. But I also added a check in the `start_session` function since that seemed like a good place to catch all the other cases and just escape out if the meta button is being pressed.

I don't think it's necessary to add a check for the operating system since I don't think Windows uses the Win key as a modifier the way Mac's command key is, since it mostly uses Ctrl/Alt for those types of events.